### PR TITLE
Judge cards: remove per-category names and normalize Red-left slider behavior

### DIFF
--- a/static/judge.js
+++ b/static/judge.js
@@ -33,6 +33,24 @@
     const redName = (state.current.red_details && state.current.red_details.name) || state.current.red || 'Red';
     const whiteName = (state.current.white_details && state.current.white_details.name) || state.current.white || 'White';
 
+    const clamp = (value, min, max) => {
+      if (!Number.isFinite(value)) {
+        return min;
+      }
+      return Math.min(Math.max(value, min), max);
+    };
+
+    sliderWrappers.forEach(wrapper => {
+      const input = wrapper.querySelector('input[type="range"]');
+      if (!input) return;
+      const maxAttr = Number(wrapper.dataset.max || input.max || 0);
+      const max = Number.isNaN(maxAttr) ? 0 : maxAttr;
+      const raw = Number(input.value || 0);
+      const redPoints = clamp(Number.isNaN(raw) ? 0 : raw, 0, max);
+      const whiteValue = clamp(max - redPoints, 0, max);
+      input.value = String(whiteValue);
+    });
+
     const computeScores = () => {
       let totalRed = 0;
       let totalWhite = 0;
@@ -40,12 +58,14 @@
       const breakdown = [];
       sliderWrappers.forEach(wrapper => {
         const key = wrapper.dataset.key;
-        const max = Number(wrapper.dataset.max || 0);
         const input = wrapper.querySelector('input[type="range"]');
         if (!input) return;
-        const value = Number(input.value || 0);
-        const redPoints = Math.max(0, Math.min(max, value));
-        const whitePoints = max - redPoints;
+        const maxAttr = Number(wrapper.dataset.max || input.max || 0);
+        const maxValue = Number.isNaN(maxAttr) ? 0 : maxAttr;
+        const rawWhite = Number(input.value || 0);
+        const whitePoints = clamp(Number.isNaN(rawWhite) ? 0 : rawWhite, 0, maxValue);
+        const redPoints = clamp(maxValue - whitePoints, 0, maxValue);
+        input.value = String(whitePoints);
         const redDisplay = wrapper.querySelector('[data-red-points]');
         const whiteDisplay = wrapper.querySelector('[data-white-points]');
         if (redDisplay) redDisplay.textContent = String(redPoints);

--- a/static/style.css
+++ b/static/style.css
@@ -84,7 +84,7 @@ dialog::backdrop{background:rgba(0,0,0,0.65)}
 .judge-fight-card{display:grid;grid-template-columns:1fr minmax(140px,180px) 1fr;gap:16px;align-items:center;background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:12px}
 .judge-robot{text-align:center;display:flex;flex-direction:column;gap:6px;min-width:0}
 .judge-robot-image{max-width:100%;max-height:220px;border-radius:6px;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,0.35)}
-.judge-robot-name{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:24px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%}
+.judge-robot-name{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:24px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;white-space:normal;max-width:100%}
 .judge-fight-info{text-align:center;display:flex;flex-direction:column;gap:6px;justify-content:center}
 .judge-vs{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:40px;color:var(--red)}
 
@@ -92,8 +92,8 @@ dialog::backdrop{background:rgba(0,0,0,0.65)}
 .judge-slider-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 .judge-slider{background:#1b1d21;border:1px solid #2a2e33;border-radius:6px;padding:10px;display:grid;gap:6px}
 .judge-slider-header{display:flex;align-items:center;justify-content:space-between;font-weight:600}
-.judge-slider-input{display:flex;align-items:center;gap:10px;min-width:0}
-.judge-slider-input input[type=range]{flex:1}
+.judge-slider-input{display:block;min-width:0}
+.judge-slider-input input[type=range]{width:100%}
 .slider-label{font-weight:600;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%;min-width:0;flex-shrink:1}
 .slider-label.red{color:var(--red)}
 .slider-label.white{color:var(--blue)}

--- a/templates/judge.html
+++ b/templates/judge.html
@@ -39,14 +39,12 @@
             <span class="small">Max {{ spec.max }} pts</span>
           </div>
           <div class="judge-slider-input">
-            <span class="slider-label white" title="{{ current.white_details.name }}">{{ current.white_details.name }}</span>
             <input type="range" min="0" max="{{ spec.max }}" step="1" value="{{ slider }}">
-            <span class="slider-label red" title="{{ current.red_details.name }}">{{ current.red_details.name }}</span>
           </div>
           <div class="judge-slider-values">
-            <span class="white" data-white-points>0</span>
-            <span class="small">Points</span>
             <span class="red" data-red-points>0</span>
+            <span class="small">Points</span>
+            <span class="white" data-white-points>0</span>
           </div>
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- drop robot name labels from each judge slider and show red points to the left of white points
- normalize judge slider math so the input represents white points while submissions continue to send red totals
- widen the slider control and allow top robot names to wrap across two lines

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d3e432c9f0832a9f0edb0237b94d4b