### PR TITLE
Fix judge slider script packaging

### DIFF
--- a/static/judge.js
+++ b/static/judge.js
@@ -1,4 +1,3 @@
-<script>
 (function () {
   document.addEventListener('DOMContentLoaded', () => {
     const state = window.JUDGE_PAGE_STATE || null;
@@ -215,4 +214,3 @@
     });
   });
 })();
-</script>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,34 @@
+import unittest
+from flask import url_for
+
+import app as bot_app
+
+
+class AppRoutesTestCase(unittest.TestCase):
+    def setUp(self):
+        bot_app.app.config["TESTING"] = True
+        self.client = bot_app.app.test_client()
+
+    def test_robot_display_handles_invalid_weight_class(self):
+        result = bot_app.robot_display("Unknown", "TestBot")
+        self.assertEqual(result["name"], "TestBot")
+        self.assertIsNone(result["rating"])
+        self.assertEqual(result["wins"], 0)
+        self.assertEqual(result["losses"], 0)
+        self.assertEqual(result["draws"], 0)
+        self.assertEqual(result["ko_wins"], 0)
+        self.assertEqual(result["ko_losses"], 0)
+
+    def test_robot_presence_invalid_weight_class_redirects(self):
+        response = self.client.post(
+            "/robot/presence",
+            data={"wc": "Unknown", "name": "TestBot", "present": "1"},
+        )
+        self.assertEqual(response.status_code, 302)
+        with bot_app.app.test_request_context():
+            expected = url_for("index", wc=bot_app.WEIGHT_CLASSES[0], _external=False)
+        self.assertEqual(response.headers.get("Location"), expected)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove stray <script> tags from the bundled judge.js asset so the browser executes it
- restore real-time slider point calculations on the judging page

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68d509ca9748832ab797a9cfcc1f61bf