### PR TITLE
Update antweight, beetleweight, and sumo elo databases

### DIFF
--- a/data/elo_antweights.txt
+++ b/data/elo_antweights.txt
@@ -1,7 +1,7 @@
 {
   "robots": {
     "Left Shoe Right Foot": {
-      "rating": 1002,
+      "rating": 971,
       "matches": [
         {
           "match_id": 2,
@@ -28,12 +28,38 @@
           "new_rating_white": 1002,
           "change_red": -17,
           "change_white": 17
+        },
+        {
+          "match_id": 4,
+          "timestamp": 1758324992,
+          "red_corner": "Left Shoe Right Foot",
+          "white_corner": "Sawshimi",
+          "result": "White wins KO",
+          "old_rating_red": 1002,
+          "old_rating_white": 1000,
+          "new_rating_red": 986,
+          "new_rating_white": 1019,
+          "change_red": -16,
+          "change_white": 19
+        },
+        {
+          "match_id": 6,
+          "timestamp": 1758327365,
+          "red_corner": "Fanter",
+          "white_corner": "Left Shoe Right Foot",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 986,
+          "new_rating_red": 1019,
+          "new_rating_white": 971,
+          "change_red": 19,
+          "change_white": -15
         }
       ],
       "driver_name": "Garrett",
       "team_name": "Botshed Robotics",
       "weight_class": "Antweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757681027325_Left_Shoe_Right_Foot_transp.png"
     },
     "Mini Vortex": {
@@ -96,12 +122,52 @@
       "image": "/static/uploads/1757681677135_Shredder_transp.png"
     },
     "Sawshimi": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1018,
+      "matches": [
+        {
+          "match_id": 4,
+          "timestamp": 1758324992,
+          "red_corner": "Left Shoe Right Foot",
+          "white_corner": "Sawshimi",
+          "result": "White wins KO",
+          "old_rating_red": 1002,
+          "old_rating_white": 1000,
+          "new_rating_red": 986,
+          "new_rating_white": 1019,
+          "change_red": -16,
+          "change_white": 19
+        },
+        {
+          "match_id": 7,
+          "timestamp": 1758329216,
+          "red_corner": "Sawshimi",
+          "white_corner": "Pistol Shrimp",
+          "result": "Red wins JD",
+          "old_rating_red": 1019,
+          "old_rating_white": 1019,
+          "new_rating_red": 1035,
+          "new_rating_white": 1003,
+          "change_red": 16,
+          "change_white": -16
+        },
+        {
+          "match_id": 8,
+          "timestamp": 1758332545,
+          "red_corner": "Fanter",
+          "white_corner": "Sawshimi",
+          "result": "Red wins KO",
+          "old_rating_red": 1019,
+          "old_rating_white": 1035,
+          "new_rating_red": 1039,
+          "new_rating_white": 1018,
+          "change_red": 20,
+          "change_white": -17
+        }
+      ],
       "driver_name": "Damian",
       "team_name": "LOUDHOUSE",
       "weight_class": "Antweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757920542980_sawshimi_transp.png"
     },
     "Royal Reaper": {
@@ -128,29 +194,97 @@
       "image": "/static/uploads/1757682050687_Royal_Reaper_transp.png"
     },
     "Pistol Shrimp": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1003,
+      "matches": [
+        {
+          "match_id": 5,
+          "timestamp": 1758326349,
+          "red_corner": "Pistol Shrimp",
+          "white_corner": "Dragonfly",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1000,
+          "new_rating_red": 1019,
+          "new_rating_white": 984,
+          "change_red": 19,
+          "change_white": -16
+        },
+        {
+          "match_id": 7,
+          "timestamp": 1758329216,
+          "red_corner": "Sawshimi",
+          "white_corner": "Pistol Shrimp",
+          "result": "Red wins JD",
+          "old_rating_red": 1019,
+          "old_rating_white": 1019,
+          "new_rating_red": 1035,
+          "new_rating_white": 1003,
+          "change_red": 16,
+          "change_white": -16
+        }
+      ],
       "driver_name": "Lucas",
       "team_name": "Dremel Gaming Robotics",
       "weight_class": "Antweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757920416986_pistol_shrimp_transp.png"
     },
     "Dragonfly": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 984,
+      "matches": [
+        {
+          "match_id": 5,
+          "timestamp": 1758326349,
+          "red_corner": "Pistol Shrimp",
+          "white_corner": "Dragonfly",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1000,
+          "new_rating_red": 1019,
+          "new_rating_white": 984,
+          "change_red": 19,
+          "change_white": -16
+        }
+      ],
       "driver_name": "Leo",
       "team_name": "Ping Industries",
       "weight_class": "Antweights",
-      "present": true
+      "present": false
     },
     "Fanter": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1039,
+      "matches": [
+        {
+          "match_id": 6,
+          "timestamp": 1758327365,
+          "red_corner": "Fanter",
+          "white_corner": "Left Shoe Right Foot",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 986,
+          "new_rating_red": 1019,
+          "new_rating_white": 971,
+          "change_red": 19,
+          "change_white": -15
+        },
+        {
+          "match_id": 8,
+          "timestamp": 1758332545,
+          "red_corner": "Fanter",
+          "white_corner": "Sawshimi",
+          "result": "Red wins KO",
+          "old_rating_red": 1019,
+          "old_rating_white": 1035,
+          "new_rating_red": 1039,
+          "new_rating_white": 1018,
+          "change_red": 20,
+          "change_white": -17
+        }
+      ],
       "driver_name": "Benjamin",
       "team_name": "Team JOTO",
       "weight_class": "Antweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757920705019_fanter_transp.png"
     },
     "Glup": {
@@ -158,14 +292,6 @@
       "matches": [],
       "driver_name": "Benjamin",
       "team_name": "Team JOTO",
-      "weight_class": "Antweights",
-      "present": true
-    },
-    "This Is A Really Really Really Long Robot Name That Should Definitely Be Truncated": {
-      "rating": 1000,
-      "matches": [],
-      "driver_name": "TestDriver",
-      "team_name": "",
       "weight_class": "Antweights",
       "present": false
     }
@@ -209,9 +335,74 @@
       "new_rating_white": 1002,
       "change_red": -17,
       "change_white": 17
+    },
+    {
+      "match_id": 4,
+      "timestamp": 1758324992,
+      "red_corner": "Left Shoe Right Foot",
+      "white_corner": "Sawshimi",
+      "result": "White wins KO",
+      "old_rating_red": 1002,
+      "old_rating_white": 1000,
+      "new_rating_red": 986,
+      "new_rating_white": 1019,
+      "change_red": -16,
+      "change_white": 19
+    },
+    {
+      "match_id": 5,
+      "timestamp": 1758326349,
+      "red_corner": "Pistol Shrimp",
+      "white_corner": "Dragonfly",
+      "result": "Red wins KO",
+      "old_rating_red": 1000,
+      "old_rating_white": 1000,
+      "new_rating_red": 1019,
+      "new_rating_white": 984,
+      "change_red": 19,
+      "change_white": -16
+    },
+    {
+      "match_id": 6,
+      "timestamp": 1758327365,
+      "red_corner": "Fanter",
+      "white_corner": "Left Shoe Right Foot",
+      "result": "Red wins KO",
+      "old_rating_red": 1000,
+      "old_rating_white": 986,
+      "new_rating_red": 1019,
+      "new_rating_white": 971,
+      "change_red": 19,
+      "change_white": -15
+    },
+    {
+      "match_id": 7,
+      "timestamp": 1758329216,
+      "red_corner": "Sawshimi",
+      "white_corner": "Pistol Shrimp",
+      "result": "Red wins JD",
+      "old_rating_red": 1019,
+      "old_rating_white": 1019,
+      "new_rating_red": 1035,
+      "new_rating_white": 1003,
+      "change_red": 16,
+      "change_white": -16
+    },
+    {
+      "match_id": 8,
+      "timestamp": 1758332545,
+      "red_corner": "Fanter",
+      "white_corner": "Sawshimi",
+      "result": "Red wins KO",
+      "old_rating_red": 1019,
+      "old_rating_white": 1035,
+      "new_rating_red": 1039,
+      "new_rating_white": 1018,
+      "change_red": 20,
+      "change_white": -17
     }
   ],
-  "next_match_id": 4,
+  "next_match_id": 9,
   "settings": {
     "K": 32,
     "ko_weight": 1.1

--- a/data/elo_beetleweights.txt
+++ b/data/elo_beetleweights.txt
@@ -109,16 +109,30 @@
       "image": "/static/uploads/1757681806744_shrubert_transp.png"
     },
     "Kansei Dorifto": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 983,
+      "matches": [
+        {
+          "match_id": 15,
+          "timestamp": 1758331557,
+          "red_corner": "Charity Case",
+          "white_corner": "Kansei Dorifto",
+          "result": "Red wins KO",
+          "old_rating_red": 989,
+          "old_rating_white": 1000,
+          "new_rating_red": 1009,
+          "new_rating_white": 983,
+          "change_red": 20,
+          "change_white": -17
+        }
+      ],
       "driver_name": "Dan",
       "team_name": "Idle Hands",
       "weight_class": "Beetleweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757916835445_kanseiplain.png"
     },
     "Anubis": {
-      "rating": 983,
+      "rating": 956,
       "matches": [
         {
           "match_id": 9,
@@ -132,6 +146,32 @@
           "new_rating_white": 1004,
           "change_red": -17,
           "change_white": 20
+        },
+        {
+          "match_id": 11,
+          "timestamp": 1758324764,
+          "red_corner": "Anubis",
+          "white_corner": "Ipseity",
+          "result": "White wins KO",
+          "old_rating_red": 983,
+          "old_rating_white": 1038,
+          "new_rating_red": 970,
+          "new_rating_white": 1055,
+          "change_red": -13,
+          "change_white": 17
+        },
+        {
+          "match_id": 14,
+          "timestamp": 1758328013,
+          "red_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+          "white_corner": "Anubis",
+          "result": "Red wins KO",
+          "old_rating_red": 1019,
+          "old_rating_white": 970,
+          "new_rating_red": 1036,
+          "new_rating_white": 956,
+          "change_red": 17,
+          "change_white": -14
         }
       ],
       "driver_name": "Anthony",
@@ -141,7 +181,7 @@
       "image": "/static/uploads/1757915933327_Anubis_transp.png"
     },
     "Charity Case": {
-      "rating": 989,
+      "rating": 1029,
       "matches": [
         {
           "match_id": 8,
@@ -181,6 +221,32 @@
           "new_rating_white": 989,
           "change_red": 19,
           "change_white": -15
+        },
+        {
+          "match_id": 15,
+          "timestamp": 1758331557,
+          "red_corner": "Charity Case",
+          "white_corner": "Kansei Dorifto",
+          "result": "Red wins KO",
+          "old_rating_red": 989,
+          "old_rating_white": 1000,
+          "new_rating_red": 1009,
+          "new_rating_white": 983,
+          "change_red": 20,
+          "change_white": -17
+        },
+        {
+          "match_id": 16,
+          "timestamp": 1758332683,
+          "red_corner": "Charity Case",
+          "white_corner": "Ipseity",
+          "result": "Red wins KO",
+          "old_rating_red": 1009,
+          "old_rating_white": 1036,
+          "new_rating_red": 1029,
+          "new_rating_white": 1019,
+          "change_red": 20,
+          "change_white": -17
         }
       ],
       "driver_name": "Charity Case",
@@ -190,7 +256,7 @@
       "image": "/static/uploads/1757916149520_Charity_Case_transp.png"
     },
     "Ipseity": {
-      "rating": 1038,
+      "rating": 1019,
       "matches": [
         {
           "match_id": 8,
@@ -217,39 +283,123 @@
           "new_rating_white": 989,
           "change_red": 19,
           "change_white": -15
+        },
+        {
+          "match_id": 11,
+          "timestamp": 1758324764,
+          "red_corner": "Anubis",
+          "white_corner": "Ipseity",
+          "result": "White wins KO",
+          "old_rating_red": 983,
+          "old_rating_white": 1038,
+          "new_rating_red": 970,
+          "new_rating_white": 1055,
+          "change_red": -13,
+          "change_white": 17
+        },
+        {
+          "match_id": 13,
+          "timestamp": 1758326969,
+          "red_corner": "Ipseity",
+          "white_corner": "Thunderbird",
+          "result": "White wins JD",
+          "old_rating_red": 1055,
+          "old_rating_white": 984,
+          "new_rating_red": 1036,
+          "new_rating_white": 1003,
+          "change_red": -19,
+          "change_white": 19
+        },
+        {
+          "match_id": 16,
+          "timestamp": 1758332683,
+          "red_corner": "Charity Case",
+          "white_corner": "Ipseity",
+          "result": "Red wins KO",
+          "old_rating_red": 1009,
+          "old_rating_white": 1036,
+          "new_rating_red": 1029,
+          "new_rating_white": 1019,
+          "change_red": 20,
+          "change_white": -17
         }
       ],
       "driver_name": "William",
       "team_name": "Ghost",
       "weight_class": "Beetleweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757916184106_Ipseity_transp.png"
     },
-    "Pizzabot": {
-      "rating": 1000,
-      "matches": [],
-      "driver_name": "Autumn",
-      "team_name": "Capybara Biggus Piggus",
-      "weight_class": "Beetleweights",
-      "present": true,
-      "image": "/static/uploads/1757920758914_pizzabot_transp.png"
-    },
     "Thunderbird": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1003,
+      "matches": [
+        {
+          "match_id": 12,
+          "timestamp": 1758325670,
+          "red_corner": "Thunderbird",
+          "white_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+          "result": "White wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1000,
+          "new_rating_red": 984,
+          "new_rating_white": 1019,
+          "change_red": -16,
+          "change_white": 19
+        },
+        {
+          "match_id": 13,
+          "timestamp": 1758326969,
+          "red_corner": "Ipseity",
+          "white_corner": "Thunderbird",
+          "result": "White wins JD",
+          "old_rating_red": 1055,
+          "old_rating_white": 984,
+          "new_rating_red": 1036,
+          "new_rating_white": 1003,
+          "change_red": -19,
+          "change_white": 19
+        }
+      ],
       "driver_name": "Leo",
       "team_name": "Ping Industries",
       "weight_class": "Beetleweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757920941973_thunderbird_transp.png"
     },
     "Orders From the House (You're the Only Place That Feels like Home)": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1036,
+      "matches": [
+        {
+          "match_id": 12,
+          "timestamp": 1758325670,
+          "red_corner": "Thunderbird",
+          "white_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+          "result": "White wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1000,
+          "new_rating_red": 984,
+          "new_rating_white": 1019,
+          "change_red": -16,
+          "change_white": 19
+        },
+        {
+          "match_id": 14,
+          "timestamp": 1758328013,
+          "red_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+          "white_corner": "Anubis",
+          "result": "Red wins KO",
+          "old_rating_red": 1019,
+          "old_rating_white": 970,
+          "new_rating_red": 1036,
+          "new_rating_white": 956,
+          "change_red": 17,
+          "change_white": -14
+        }
+      ],
       "driver_name": "William",
       "team_name": "Ghost",
       "weight_class": "Beetleweights",
-      "present": true,
+      "present": false,
       "image": "/static/uploads/1757921064528_orders_from_the_house_transp.png"
     }
   },
@@ -331,9 +481,87 @@
       "new_rating_white": 989,
       "change_red": 19,
       "change_white": -15
+    },
+    {
+      "match_id": 11,
+      "timestamp": 1758324764,
+      "red_corner": "Anubis",
+      "white_corner": "Ipseity",
+      "result": "White wins KO",
+      "old_rating_red": 983,
+      "old_rating_white": 1038,
+      "new_rating_red": 970,
+      "new_rating_white": 1055,
+      "change_red": -13,
+      "change_white": 17
+    },
+    {
+      "match_id": 12,
+      "timestamp": 1758325670,
+      "red_corner": "Thunderbird",
+      "white_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+      "result": "White wins KO",
+      "old_rating_red": 1000,
+      "old_rating_white": 1000,
+      "new_rating_red": 984,
+      "new_rating_white": 1019,
+      "change_red": -16,
+      "change_white": 19
+    },
+    {
+      "match_id": 13,
+      "timestamp": 1758326969,
+      "red_corner": "Ipseity",
+      "white_corner": "Thunderbird",
+      "result": "White wins JD",
+      "old_rating_red": 1055,
+      "old_rating_white": 984,
+      "new_rating_red": 1036,
+      "new_rating_white": 1003,
+      "change_red": -19,
+      "change_white": 19
+    },
+    {
+      "match_id": 14,
+      "timestamp": 1758328013,
+      "red_corner": "Orders From the House (You're the Only Place That Feels like Home)",
+      "white_corner": "Anubis",
+      "result": "Red wins KO",
+      "old_rating_red": 1019,
+      "old_rating_white": 970,
+      "new_rating_red": 1036,
+      "new_rating_white": 956,
+      "change_red": 17,
+      "change_white": -14
+    },
+    {
+      "match_id": 15,
+      "timestamp": 1758331557,
+      "red_corner": "Charity Case",
+      "white_corner": "Kansei Dorifto",
+      "result": "Red wins KO",
+      "old_rating_red": 989,
+      "old_rating_white": 1000,
+      "new_rating_red": 1009,
+      "new_rating_white": 983,
+      "change_red": 20,
+      "change_white": -17
+    },
+    {
+      "match_id": 16,
+      "timestamp": 1758332683,
+      "red_corner": "Charity Case",
+      "white_corner": "Ipseity",
+      "result": "Red wins KO",
+      "old_rating_red": 1009,
+      "old_rating_white": 1036,
+      "new_rating_red": 1029,
+      "new_rating_white": 1019,
+      "change_red": 20,
+      "change_white": -17
     }
   ],
-  "next_match_id": 11,
+  "next_match_id": 17,
   "settings": {
     "K": 32,
     "ko_weight": 1.1

--- a/data/elo_sumos.txt
+++ b/data/elo_sumos.txt
@@ -1,8 +1,48 @@
 {
   "robots": {
     "Homer": {
-      "rating": 1000,
-      "matches": [],
+      "rating": 1023,
+      "matches": [
+        {
+          "match_id": 10,
+          "timestamp": 1758326100,
+          "red_corner": "Homer",
+          "white_corner": "Dispatchula",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1056,
+          "new_rating_red": 1022,
+          "new_rating_white": 1037,
+          "change_red": 22,
+          "change_white": -19
+        },
+        {
+          "match_id": 12,
+          "timestamp": 1758327803,
+          "red_corner": "Whammo Can & Driveway Hero",
+          "white_corner": "Homer",
+          "result": "White wins KO",
+          "old_rating_red": 1008,
+          "old_rating_white": 1022,
+          "new_rating_red": 993,
+          "new_rating_white": 1041,
+          "change_red": -15,
+          "change_white": 19
+        },
+        {
+          "match_id": 13,
+          "timestamp": 1758328241,
+          "red_corner": "Alpalcalypse",
+          "white_corner": "Homer",
+          "result": "Red wins KO",
+          "old_rating_red": 1005,
+          "old_rating_white": 1041,
+          "new_rating_red": 1026,
+          "new_rating_white": 1023,
+          "change_red": 21,
+          "change_white": -18
+        }
+      ],
       "driver_name": "Dan",
       "team_name": "Idle Hands",
       "weight_class": "Sumos",
@@ -18,7 +58,7 @@
       "present": false
     },
     "Dispatchula": {
-      "rating": 1056,
+      "rating": 1019,
       "matches": [
         {
           "match_id": 6,
@@ -58,6 +98,32 @@
           "new_rating_white": 988,
           "change_red": 18,
           "change_white": -14
+        },
+        {
+          "match_id": 10,
+          "timestamp": 1758326100,
+          "red_corner": "Homer",
+          "white_corner": "Dispatchula",
+          "result": "Red wins KO",
+          "old_rating_red": 1000,
+          "old_rating_white": 1056,
+          "new_rating_red": 1022,
+          "new_rating_white": 1037,
+          "change_red": 22,
+          "change_white": -19
+        },
+        {
+          "match_id": 11,
+          "timestamp": 1758326617,
+          "red_corner": "Dispatchula",
+          "white_corner": "Alpalcalypse",
+          "result": "White wins KO",
+          "old_rating_red": 1037,
+          "old_rating_white": 983,
+          "new_rating_red": 1019,
+          "new_rating_white": 1005,
+          "change_red": -18,
+          "change_white": 22
         }
       ],
       "driver_name": "Garrett",
@@ -103,7 +169,7 @@
       "image": "/static/uploads/1757918102279_bort_transp.png"
     },
     "Whammo Can & Driveway Hero": {
-      "rating": 988,
+      "rating": 993,
       "matches": [
         {
           "match_id": 5,
@@ -143,6 +209,32 @@
           "new_rating_white": 988,
           "change_red": 18,
           "change_white": -14
+        },
+        {
+          "match_id": 9,
+          "timestamp": 1758325454,
+          "red_corner": "Whammo Can & Driveway Hero",
+          "white_corner": "Alpalcalypse",
+          "result": "Red wins KO",
+          "old_rating_red": 988,
+          "old_rating_white": 1000,
+          "new_rating_red": 1008,
+          "new_rating_white": 983,
+          "change_red": 20,
+          "change_white": -17
+        },
+        {
+          "match_id": 12,
+          "timestamp": 1758327803,
+          "red_corner": "Whammo Can & Driveway Hero",
+          "white_corner": "Homer",
+          "result": "White wins KO",
+          "old_rating_red": 1008,
+          "old_rating_white": 1022,
+          "new_rating_red": 993,
+          "new_rating_white": 1041,
+          "change_red": -15,
+          "change_white": 19
         }
       ],
       "driver_name": "Garrett",
@@ -151,14 +243,62 @@
       "present": true,
       "image": "/static/uploads/1757918121341_Whammo_Can_and_Driveway_Hero_transp.png"
     },
-    "Jimmy Neutrons Hot Mom (Judy)": {
+    "Jimmy Neutron’s Hot Mom": {
       "rating": 1000,
       "matches": [],
       "driver_name": "Autumn",
-      "team_name": "Capybara Biggus Piggus",
+      "team_name": "",
+      "weight_class": "Sumos",
+      "present": true
+    },
+    "Alpacalypse": {
+      "rating": 1026,
+      "matches": [
+        {
+          "match_id": 9,
+          "timestamp": 1758325454,
+          "red_corner": "Whammo Can & Driveway Hero",
+          "white_corner": "Alpalcalypse",
+          "result": "Red wins KO",
+          "old_rating_red": 988,
+          "old_rating_white": 1000,
+          "new_rating_red": 1008,
+          "new_rating_white": 983,
+          "change_red": 20,
+          "change_white": -17
+        },
+        {
+          "match_id": 11,
+          "timestamp": 1758326617,
+          "red_corner": "Dispatchula",
+          "white_corner": "Alpalcalypse",
+          "result": "White wins KO",
+          "old_rating_red": 1037,
+          "old_rating_white": 983,
+          "new_rating_red": 1019,
+          "new_rating_white": 1005,
+          "change_red": -18,
+          "change_white": 22
+        },
+        {
+          "match_id": 13,
+          "timestamp": 1758328241,
+          "red_corner": "Alpalcalypse",
+          "white_corner": "Homer",
+          "result": "Red wins KO",
+          "old_rating_red": 1005,
+          "old_rating_white": 1041,
+          "new_rating_red": 1026,
+          "new_rating_white": 1023,
+          "change_red": 21,
+          "change_white": -18
+        }
+      ],
+      "driver_name": "Andrea",
+      "team_name": "Andrea",
       "weight_class": "Sumos",
       "present": true,
-      "image": "/static/uploads/1757921091847_Judy_transp.png"
+      "image": "/static/uploads/1758307601827_cc5508ea-ce2c-4b4e-a90a-7dbb9d3eedd4.jpg"
     }
   },
   "history": [
@@ -213,9 +353,74 @@
       "new_rating_white": 988,
       "change_red": 18,
       "change_white": -14
+    },
+    {
+      "match_id": 9,
+      "timestamp": 1758325454,
+      "red_corner": "Whammo Can & Driveway Hero",
+      "white_corner": "Alpalcalypse",
+      "result": "Red wins KO",
+      "old_rating_red": 988,
+      "old_rating_white": 1000,
+      "new_rating_red": 1008,
+      "new_rating_white": 983,
+      "change_red": 20,
+      "change_white": -17
+    },
+    {
+      "match_id": 10,
+      "timestamp": 1758326100,
+      "red_corner": "Homer",
+      "white_corner": "Dispatchula",
+      "result": "Red wins KO",
+      "old_rating_red": 1000,
+      "old_rating_white": 1056,
+      "new_rating_red": 1022,
+      "new_rating_white": 1037,
+      "change_red": 22,
+      "change_white": -19
+    },
+    {
+      "match_id": 11,
+      "timestamp": 1758326617,
+      "red_corner": "Dispatchula",
+      "white_corner": "Alpalcalypse",
+      "result": "White wins KO",
+      "old_rating_red": 1037,
+      "old_rating_white": 983,
+      "new_rating_red": 1019,
+      "new_rating_white": 1005,
+      "change_red": -18,
+      "change_white": 22
+    },
+    {
+      "match_id": 12,
+      "timestamp": 1758327803,
+      "red_corner": "Whammo Can & Driveway Hero",
+      "white_corner": "Homer",
+      "result": "White wins KO",
+      "old_rating_red": 1008,
+      "old_rating_white": 1022,
+      "new_rating_red": 993,
+      "new_rating_white": 1041,
+      "change_red": -15,
+      "change_white": 19
+    },
+    {
+      "match_id": 13,
+      "timestamp": 1758328241,
+      "red_corner": "Alpalcalypse",
+      "white_corner": "Homer",
+      "result": "Red wins KO",
+      "old_rating_red": 1005,
+      "old_rating_white": 1041,
+      "new_rating_red": 1026,
+      "new_rating_white": 1023,
+      "change_red": 21,
+      "change_white": -18
     }
   ],
-  "next_match_id": 9,
+  "next_match_id": 14,
   "settings": {
     "K": 32,
     "ko_weight": 1.1


### PR DESCRIPTION
## Summary
- replace the antweight database with the latest robot, match, and history records provided
- replace the beetleweight database with the latest robot, match, and history records provided
- replace the sumo database with the latest robot, match, and history records provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5478924ec832aaae28f22f41749e4