### PR TITLE
Keep schedule generation controls within footer row

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -45,6 +45,12 @@ td.right,th.right{text-align:right}
 .footer form,label,.footer select,.footer input{font-size:13px}
 .footer label{margin:0;display:flex;flex-direction:column;gap:2px;font-size:12px}
 .footer h3{font-size:16px}
+.footer .footer-primary-actions{align-items:flex-end}
+.footer .footer-primary-actions form{margin:0}
+.footer .footer-generate-form{display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end;padding:6px 8px;border:1px solid #2a2e33;border-radius:6px;background:#151719}
+.footer .footer-generate-fields{display:flex;gap:8px;flex-wrap:wrap}
+.footer .footer-generate-form label{min-width:140px}
+.footer .footer-clear-form{align-self:flex-end}
 .footer .footer-manual-add{margin-top:8px !important;padding-top:4px;border-top:1px solid #2a2e33}
 .footer .footer-manual-add h3{font-size:15px}
 .footer .footer-manual-add form{gap:6px !important}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -64,26 +64,6 @@
       </tbody>
     </table>
 
-    <hr class="sep">
-
-    <form method="post" action="/schedule/generate" class="grid grid-2">
-      <label>
-        Matches / Robot
-        <input type="number" name="matchesPerRobot" value="1" min="1" max="10">
-      </label>
-      <label>
-        Interleave Classes
-        <select name="interleave">
-          <option value="1" selected>Yes</option>
-          <option value="0">No</option>
-        </select>
-      </label>
-      <button class="btn btn-green" type="submit">Generate</button>
-    </form>
-
-    <form method="post" action="/schedule/clear" style="margin-top:8px">
-      <button class="btn btn-red" type="submit">Clear</button>
-    </form>
   </div>
 
   <div style="margin-top:12px;">
@@ -106,7 +86,7 @@
 
   <!-- Footer Controls -->
   <div class="footer">
-    <div class="row">
+    <div class="row footer-primary-actions">
       <span class="badge">
         {% if top %}
           Top: {{ top.red }} vs {{ top.white }} ({{ top.weight_class }})
@@ -114,6 +94,27 @@
           Schedule empty
         {% endif %}
       </span>
+
+      <form method="post" action="/schedule/generate" class="footer-generate-form">
+        <div class="footer-generate-fields">
+          <label>
+            Matches / Robot
+            <input type="number" name="matchesPerRobot" value="1" min="1" max="10">
+          </label>
+          <label>
+            Interleave Classes
+            <select name="interleave">
+              <option value="1" selected>Yes</option>
+              <option value="0">No</option>
+            </select>
+          </label>
+        </div>
+        <button class="btn btn-green" type="submit">Generate</button>
+      </form>
+
+      <form method="post" action="/schedule/clear" class="footer-clear-form">
+        <button class="btn btn-red" type="submit">Clear</button>
+      </form>
 
       <form method="post" action="/submit_match" style="display:flex;gap:10px;flex-wrap:wrap;align-items:end">
         <input type="hidden" name="popFromSchedule" value="1">


### PR DESCRIPTION
## Summary
- keep the schedule generate and clear actions inside the footer control row rather than the robot presence panel
- adjust the footer layout classes so the generation controls align cleanly with the existing footer actions

## Testing
- python -m compileall templates/schedule.html

------
https://chatgpt.com/codex/tasks/task_e_68de72764b1c832abbaae51adaa6f8d0