### PR TITLE
Allow schedule engine to load database automatically

### DIFF
--- a/tests/test_schedule_engine.py
+++ b/tests/test_schedule_engine.py
@@ -1,6 +1,34 @@
 import schedule_engine
 
 
+def test_generate_loads_db_when_not_provided(monkeypatch):
+    sample_db = {
+        "feather": {
+            "robots": {
+                "Alpha": {"present": True, "rating": 1000},
+                "Bravo": {"present": True, "rating": 1000},
+            },
+            "history": [],
+        }
+    }
+
+    calls = {"count": 0}
+
+    def fake_load_all():
+        calls["count"] += 1
+        return sample_db
+
+    monkeypatch.setattr(schedule_engine, "_load_all_dbs", fake_load_all)
+
+    schedule = schedule_engine.generate(seed=1)
+
+    assert calls["count"] == 1
+    assert len(schedule) == 1
+    match = schedule[0]
+    assert match["weight_class"] == "feather"
+    assert {match["red"], match["white"]} == {"Alpha", "Bravo"}
+
+
 def test_has_unscheduled_fresh_opponent_recognizes_available_pair():
     db = {
         'feather': {


### PR DESCRIPTION
## Summary
- make the schedule engine load databases from storage when no explicit data is supplied
- raise a helpful error if storage is unavailable
- add a regression test ensuring generate() loads the databases and produces matches

## Testing
- pytest BotBrawlDB/tests/test_schedule_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68df82e87de4832aa4a1b80efc115dbf