### PR TITLE
Add distinct borders to judge robot images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -105,6 +105,8 @@ dialog::backdrop{background:rgba(0,0,0,0.65)}
 .judge-fight-card{display:grid;grid-template-columns:1fr minmax(140px,180px) 1fr;gap:16px;align-items:center;background:var(--panel2);border:1px solid #2a2e33;border-radius:6px;padding:12px}
 .judge-robot{text-align:center;display:flex;flex-direction:column;gap:6px;min-width:0}
 .judge-robot-image{max-width:100%;max-height:220px;border-radius:6px;object-fit:cover;box-shadow:0 4px 12px rgba(0,0,0,0.35)}
+.judge-robot-red .judge-robot-image{border:4px solid #c00}
+.judge-robot-white .judge-robot-image{border:4px solid #fff}
 .judge-robot-name{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:24px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;white-space:normal;max-width:100%}
 .judge-fight-info{text-align:center;display:flex;flex-direction:column;gap:6px;justify-content:center}
 .judge-vs{font-family:'Bank Gothic','BankGothic Md BT',Michroma,'Eurostile','Square 721',sans-serif;font-size:40px;color:var(--red)}


### PR DESCRIPTION
## Summary
- add a red border to the red corner robot image on judging pages
- add a white border to the white corner robot image to visually differentiate corners

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c148b6fc832a979d525d87f9650f