### PR TITLE
Record judged matches in Elo history

### DIFF
--- a/schedule_engine.py
+++ b/schedule_engine.py
@@ -1,7 +1,9 @@
 import random
-from typing import Dict, Optional
+import unicodedata
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 from elo import DEFAULT_RATING
+
 
 try:  # pragma: no cover - fallback for tests that provide db explicitly
     from storage import load_all as _load_all_dbs


### PR DESCRIPTION
## Summary
- add a reusable helper for recording match results into the Elo database
- post judged match decisions into the Elo history when all cards are submitted
- reuse the helper for manual submissions and ensure scheduling imports include unicodedata

## Testing
- pytest tests/test_app.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b4939980832aa77c6fedd9d1168c